### PR TITLE
feat(ui): globals.cssにOKLCHカラー定義を追加

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,1 +1,36 @@
 @import "tailwindcss";
+
+:root {
+  --background: oklch(0.98 0 0);
+  --foreground: oklch(0.15 0.01 255);
+  --primary: oklch(0.35 0.08 230);
+  --primary-foreground: oklch(0.98 0 0);
+  --success: oklch(0.65 0.17 160);
+  --warning: oklch(0.75 0.15 85);
+  --danger: oklch(0.55 0.22 27);
+}
+
+.dark {
+  --background: oklch(0.15 0.01 255);
+  --foreground: oklch(0.98 0 0);
+  --primary: oklch(0.55 0.1 230);
+  --primary-foreground: oklch(0.1 0 0);
+  --success: oklch(0.7 0.16 160);
+  --warning: oklch(0.8 0.14 85);
+  --danger: oklch(0.62 0.22 27);
+}
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-success: var(--success);
+  --color-warning: var(--warning);
+  --color-danger: var(--danger);
+}
+
+body {
+  background: var(--background);
+  color: var(--foreground);
+}


### PR DESCRIPTION
## 概要
Issue #2 に対応し、`src/app/globals.css` に OKLCH カラー変数と `@theme inline` を追加しました。

## 変更内容
- `:root` にライトテーマの OKLCH 変数を定義
- `.dark` にダークテーマの OKLCH 変数を定義
- `@theme inline` で `--color-*` を公開
- `primary`, `primary-foreground`, `success`, `warning`, `danger` を定義
- `body` に `background` / `foreground` を適用

## Issue #2 AC
- [x] `:root` に OKLCH 形式でライトテーマ変数
- [x] `.dark` に OKLCH 形式でダークテーマ変数
- [x] `@theme inline` で Tailwind ユーティリティへ公開
- [x] 基本カラー（primary, primary-foreground, success, warning, danger）定義
- [x] HSL 不使用（OKLCHのみ）
- [x] `tailwind.config` でのカラー定義なし

Closes #2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Implemented a comprehensive theming system using CSS variables to define and manage application colors including background, foreground, primary, success, warning, and danger states.
  * Added dark mode support with automatic color scheme switching based on system preferences.
  * Integrated theme variables with Tailwind CSS for consistent styling throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->