### PR TITLE
feat(task): カンバンボード + タスク一覧・作成

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@prisma/client": "^6.5.0",
         "bcryptjs": "^3.0.3",
+        "date-fns": "^4.1.0",
         "lucide-react": "^1.7.0",
         "next": "16.2.0",
         "next-auth": "^5.0.0-beta.30",
@@ -1720,6 +1721,16 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/deepmerge-ts": {
       "version": "7.1.5",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@prisma/client": "^6.5.0",
     "bcryptjs": "^3.0.3",
+    "date-fns": "^4.1.0",
     "lucide-react": "^1.7.0",
     "next": "16.2.0",
     "next-auth": "^5.0.0-beta.30",

--- a/src/app/(main)/projects/[id]/board/page.tsx
+++ b/src/app/(main)/projects/[id]/board/page.tsx
@@ -1,0 +1,61 @@
+import { redirect } from 'next/navigation'
+
+import { prisma } from '@/lib/prisma'
+import { auth } from '@/lib/auth'
+import { KanbanBoard } from '@/components/board/KanbanBoard'
+
+interface BoardPageProps {
+  params: Promise<{ id: string }>
+}
+
+const BoardPage = async ({ params }: BoardPageProps) => {
+  const session = await auth()
+  if (!session?.user) {
+    redirect('/login')
+  }
+
+  const { id: projectId } = await params
+
+  const project = await prisma.project.findUnique({
+    where: { id: projectId },
+  })
+
+  if (!project) {
+    redirect('/projects')
+  }
+
+  const tasks = await prisma.task.findMany({
+    where: { projectId },
+    include: {
+      assignee: { select: { id: true, name: true, avatarUrl: true } },
+      reporter: { select: { id: true, name: true, avatarUrl: true } },
+    },
+    orderBy: [{ sortOrder: 'asc' }, { createdAt: 'desc' }],
+  })
+
+  const serializedTasks = tasks.map((task) => ({
+    ...task,
+    dueDate: task.dueDate?.toISOString() ?? null,
+    startDate: task.startDate?.toISOString() ?? null,
+    createdAt: task.createdAt.toISOString(),
+    updatedAt: task.updatedAt.toISOString(),
+  }))
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-foreground">{project.name}</h1>
+          <p className="text-sm text-foreground/60">カンバンボード</p>
+        </div>
+      </div>
+
+      <KanbanBoard
+        tasks={serializedTasks}
+        projectId={projectId}
+        projectKey={project.key}
+      />
+    </div>
+  )
+}
+export default BoardPage

--- a/src/app/api/projects/[id]/tasks/route.ts
+++ b/src/app/api/projects/[id]/tasks/route.ts
@@ -1,0 +1,127 @@
+import { NextResponse } from 'next/server'
+
+import { prisma } from '@/lib/prisma'
+import { auth } from '@/lib/auth'
+import { createTaskSchema } from '@/lib/validations/task'
+
+import type { NextRequest } from 'next/server'
+
+export const GET = async (
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  try {
+    const session = await auth()
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: { code: 'UNAUTHORIZED', message: '認証が必要です' } },
+        { status: 401 },
+      )
+    }
+
+    const { id: projectId } = await params
+
+    const project = await prisma.project.findUnique({
+      where: { id: projectId },
+    })
+    if (!project) {
+      return NextResponse.json(
+        { error: { code: 'NOT_FOUND', message: 'プロジェクトが見つかりません' } },
+        { status: 404 },
+      )
+    }
+
+    const tasks = await prisma.task.findMany({
+      where: { projectId },
+      include: {
+        assignee: { select: { id: true, name: true, avatarUrl: true } },
+        reporter: { select: { id: true, name: true, avatarUrl: true } },
+        taskCategories: { include: { category: true } },
+      },
+      orderBy: [{ sortOrder: 'asc' }, { createdAt: 'desc' }],
+    })
+
+    return NextResponse.json({ data: tasks })
+  } catch (error) {
+    console.error('[GET /api/projects/[id]/tasks]', error)
+    return NextResponse.json(
+      { error: { code: 'INTERNAL_ERROR', message: 'サーバーエラーが発生しました' } },
+      { status: 500 },
+    )
+  }
+}
+
+export const POST = async (
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  try {
+    const session = await auth()
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: { code: 'UNAUTHORIZED', message: '認証が必要です' } },
+        { status: 401 },
+      )
+    }
+
+    const { id: projectId } = await params
+
+    const project = await prisma.project.findUnique({
+      where: { id: projectId },
+    })
+    if (!project) {
+      return NextResponse.json(
+        { error: { code: 'NOT_FOUND', message: 'プロジェクトが見つかりません' } },
+        { status: 404 },
+      )
+    }
+
+    const body = await request.json()
+    const parsed = createTaskSchema.safeParse(body)
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: parsed.error.issues[0].message,
+          },
+        },
+        { status: 400 },
+      )
+    }
+
+    const lastTask = await prisma.task.findFirst({
+      where: { projectId },
+      orderBy: { taskNumber: 'desc' },
+      select: { taskNumber: true },
+    })
+    const taskNumber = (lastTask?.taskNumber ?? 0) + 1
+
+    const task = await prisma.task.create({
+      data: {
+        title: parsed.data.title,
+        description: parsed.data.description,
+        priority: parsed.data.priority,
+        status: parsed.data.status,
+        assigneeId: parsed.data.assigneeId || null,
+        dueDate: parsed.data.dueDate ? new Date(parsed.data.dueDate) : null,
+        projectId,
+        reporterId: session.user.id,
+        taskNumber,
+      },
+      include: {
+        assignee: { select: { id: true, name: true, avatarUrl: true } },
+        reporter: { select: { id: true, name: true, avatarUrl: true } },
+      },
+    })
+
+    return NextResponse.json({ data: task }, { status: 201 })
+  } catch (error) {
+    console.error('[POST /api/projects/[id]/tasks]', error)
+    return NextResponse.json(
+      { error: { code: 'INTERNAL_ERROR', message: 'サーバーエラーが発生しました' } },
+      { status: 500 },
+    )
+  }
+}

--- a/src/components/board/KanbanBoard.tsx
+++ b/src/components/board/KanbanBoard.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { useState } from 'react'
+
+import { KanbanColumn } from '@/components/board/KanbanColumn'
+import { TaskCreateModal } from '@/components/tasks/TaskCreateModal'
+
+import type { Priority, TaskStatus } from '@prisma/client'
+
+interface Task {
+  id: string
+  taskNumber: number
+  title: string
+  priority: Priority
+  status: TaskStatus
+  dueDate: string | Date | null
+  assignee: {
+    id: string
+    name: string
+    avatarUrl: string | null
+  } | null
+}
+
+interface KanbanBoardProps {
+  tasks: Task[]
+  projectId: string
+  projectKey: string
+}
+
+const columns: { status: TaskStatus; label: string }[] = [
+  { status: 'BACKLOG', label: 'Backlog' },
+  { status: 'TODO', label: 'Todo' },
+  { status: 'IN_PROGRESS', label: 'In Progress' },
+  { status: 'IN_REVIEW', label: 'In Review' },
+  { status: 'DONE', label: 'Done' },
+]
+
+export const KanbanBoard = ({ tasks, projectId, projectKey }: KanbanBoardProps) => {
+  const [showCreateModal, setShowCreateModal] = useState(false)
+  const [defaultStatus, setDefaultStatus] = useState<TaskStatus>('BACKLOG')
+
+  const handleQuickCreate = (status: TaskStatus) => {
+    setDefaultStatus(status)
+    setShowCreateModal(true)
+  }
+
+  return (
+    <>
+      <div className="flex gap-4 overflow-x-auto pb-4">
+        {columns.map((col) => (
+          <KanbanColumn
+            key={col.status}
+            status={col.status}
+            label={col.label}
+            tasks={tasks.filter((t) => t.status === col.status)}
+            projectKey={projectKey}
+            onQuickCreate={handleQuickCreate}
+          />
+        ))}
+      </div>
+
+      {showCreateModal && (
+        <TaskCreateModal
+          projectId={projectId}
+          defaultStatus={defaultStatus}
+          onClose={() => setShowCreateModal(false)}
+        />
+      )}
+    </>
+  )
+}

--- a/src/components/board/KanbanColumn.tsx
+++ b/src/components/board/KanbanColumn.tsx
@@ -1,0 +1,61 @@
+import { Plus } from "lucide-react";
+
+import { TaskCard } from "@/components/tasks/TaskCard";
+
+import type { Priority, TaskStatus } from "@prisma/client";
+
+interface Task {
+  id: string;
+  taskNumber: number;
+  title: string;
+  priority: Priority;
+  status: TaskStatus;
+  dueDate: string | Date | null;
+  assignee: {
+    id: string;
+    name: string;
+    avatarUrl: string | null;
+  } | null;
+}
+
+interface KanbanColumnProps {
+  status: TaskStatus;
+  label: string;
+  tasks: Task[];
+  projectKey: string;
+  onQuickCreate: (status: TaskStatus) => void;
+}
+
+export const KanbanColumn = ({
+  status,
+  label,
+  tasks,
+  projectKey,
+  onQuickCreate,
+}: KanbanColumnProps) => {
+  return (
+    <div className="flex w-72 shrink-0 flex-col rounded-lg bg-foreground/3">
+      <div className="flex items-center justify-between px-3 py-2">
+        <div className="flex items-center gap-2">
+          <h3 className="text-sm font-semibold text-foreground/70">{label}</h3>
+          <span className="flex h-5 min-w-5 items-center justify-center rounded-full bg-foreground/10 px-1.5 text-xs text-foreground/50">
+            {tasks.length}
+          </span>
+        </div>
+        <button
+          onClick={() => onQuickCreate(status)}
+          className="flex h-6 w-6 items-center justify-center rounded text-foreground/40 hover:bg-foreground/10 hover:text-foreground"
+          aria-label={`${label}にタスクを追加`}
+        >
+          <Plus size={14} />
+        </button>
+      </div>
+
+      <div className="flex-1 space-y-2 overflow-y-auto px-2 pb-2">
+        {tasks.map((task) => (
+          <TaskCard key={task.id} task={task} projectKey={projectKey} />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/components/tasks/TaskCard.tsx
+++ b/src/components/tasks/TaskCard.tsx
@@ -1,0 +1,67 @@
+import { Calendar, User } from 'lucide-react'
+import { format } from 'date-fns'
+
+import type { Priority } from '@prisma/client'
+
+interface TaskCardProps {
+  task: {
+    id: string
+    taskNumber: number
+    title: string
+    priority: Priority
+    dueDate: string | Date | null
+    assignee: {
+      id: string
+      name: string
+      avatarUrl: string | null
+    } | null
+  }
+  projectKey: string
+}
+
+const priorityConfig: Record<Priority, { label: string; className: string }> = {
+  URGENT: { label: '緊急', className: 'bg-danger/10 text-danger' },
+  HIGH: { label: '高', className: 'bg-warning/10 text-warning' },
+  MEDIUM: { label: '中', className: 'bg-primary/10 text-primary' },
+  LOW: { label: '低', className: 'bg-foreground/10 text-foreground/60' },
+  NONE: { label: '-', className: 'bg-foreground/5 text-foreground/40' },
+}
+
+export const TaskCard = ({ task, projectKey }: TaskCardProps) => {
+  const priority = priorityConfig[task.priority]
+  const dueDate = task.dueDate ? new Date(task.dueDate) : null
+  const isOverdue = dueDate ? dueDate < new Date() : false
+
+  return (
+    <div className="rounded-lg border border-foreground/10 bg-background p-3 shadow-sm transition-shadow hover:shadow-md">
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-xs text-foreground/40">
+          {projectKey}-{task.taskNumber}
+        </span>
+        {task.priority !== 'NONE' && (
+          <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${priority.className}`}>
+            {priority.label}
+          </span>
+        )}
+      </div>
+
+      <p className="text-sm font-medium text-foreground">{task.title}</p>
+
+      <div className="mt-3 flex items-center justify-between">
+        {dueDate && (
+          <div className={`flex items-center gap-1 text-xs ${isOverdue ? 'text-danger' : 'text-foreground/50'}`}>
+            <Calendar size={12} />
+            <span>{format(dueDate, 'M/d')}</span>
+          </div>
+        )}
+        {!dueDate && <div />}
+
+        {task.assignee && (
+          <div className="flex h-6 w-6 items-center justify-center rounded-full bg-primary/20 text-xs font-medium text-primary" title={task.assignee.name}>
+            {task.assignee.name.charAt(0).toUpperCase()}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/tasks/TaskCreateModal.tsx
+++ b/src/components/tasks/TaskCreateModal.tsx
@@ -1,0 +1,180 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+import { X } from 'lucide-react'
+
+import { createTaskSchema } from '@/lib/validations/task'
+
+import type { CreateTaskInput } from '@/lib/validations/task'
+import type { TaskStatus } from '@prisma/client'
+
+interface TaskCreateModalProps {
+  projectId: string
+  defaultStatus: TaskStatus
+  onClose: () => void
+}
+
+export const TaskCreateModal = ({
+  projectId,
+  defaultStatus,
+  onClose,
+}: TaskCreateModalProps) => {
+  const router = useRouter()
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [fieldErrors, setFieldErrors] = useState<Partial<Record<keyof CreateTaskInput, string>>>({})
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    setError('')
+    setFieldErrors({})
+
+    const formData = new FormData(e.currentTarget)
+    const data = {
+      title: formData.get('title') as string,
+      description: (formData.get('description') as string) || undefined,
+      priority: formData.get('priority') as string,
+      status: defaultStatus,
+      dueDate: (formData.get('dueDate') as string) || undefined,
+    }
+
+    const parsed = createTaskSchema.safeParse(data)
+    if (!parsed.success) {
+      const errors: Partial<Record<keyof CreateTaskInput, string>> = {}
+      for (const issue of parsed.error.issues) {
+        const field = issue.path[0] as keyof CreateTaskInput
+        if (!errors[field]) errors[field] = issue.message
+      }
+      setFieldErrors(errors)
+      return
+    }
+
+    setLoading(true)
+    try {
+      const res = await fetch(`/api/projects/${projectId}/tasks`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(parsed.data),
+      })
+
+      const json = await res.json()
+
+      if (!res.ok) {
+        setError(json.error?.message ?? 'タスクの作成に失敗しました')
+        return
+      }
+
+      router.refresh()
+      onClose()
+    } catch {
+      setError('タスクの作成中にエラーが発生しました')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-foreground/20">
+      <div className="w-full max-w-lg rounded-lg border border-foreground/10 bg-background p-6 shadow-xl">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-foreground">タスクを作成</h2>
+          <button
+            onClick={onClose}
+            className="flex h-8 w-8 items-center justify-center rounded-md text-foreground/60 hover:bg-foreground/5 hover:text-foreground"
+            aria-label="閉じる"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        {error && (
+          <div className="mb-4 rounded-md bg-danger/10 p-3 text-sm text-danger">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label htmlFor="title" className="mb-1 block text-sm font-medium text-foreground">
+              タイトル <span className="text-danger">*</span>
+            </label>
+            <input
+              id="title"
+              name="title"
+              type="text"
+              className="w-full rounded-md border border-foreground/20 bg-background px-3 py-2 text-sm text-foreground placeholder:text-foreground/40 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+              placeholder="タスクのタイトル"
+            />
+            {fieldErrors.title && (
+              <p className="mt-1 text-sm text-danger">{fieldErrors.title}</p>
+            )}
+          </div>
+
+          <div>
+            <label htmlFor="description" className="mb-1 block text-sm font-medium text-foreground">
+              説明
+            </label>
+            <textarea
+              id="description"
+              name="description"
+              rows={3}
+              className="w-full rounded-md border border-foreground/20 bg-background px-3 py-2 text-sm text-foreground placeholder:text-foreground/40 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+              placeholder="タスクの説明（Markdown対応）"
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label htmlFor="priority" className="mb-1 block text-sm font-medium text-foreground">
+                優先度
+              </label>
+              <select
+                id="priority"
+                name="priority"
+                defaultValue="NONE"
+                className="w-full rounded-md border border-foreground/20 bg-background px-3 py-2 text-sm text-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+              >
+                <option value="NONE">なし</option>
+                <option value="LOW">低</option>
+                <option value="MEDIUM">中</option>
+                <option value="HIGH">高</option>
+                <option value="URGENT">緊急</option>
+              </select>
+            </div>
+
+            <div>
+              <label htmlFor="dueDate" className="mb-1 block text-sm font-medium text-foreground">
+                期限
+              </label>
+              <input
+                id="dueDate"
+                name="dueDate"
+                type="date"
+                className="w-full rounded-md border border-foreground/20 bg-background px-3 py-2 text-sm text-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+              />
+            </div>
+          </div>
+
+          <div className="flex justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md border border-foreground/20 px-4 py-2 text-sm font-medium text-foreground hover:bg-foreground/5"
+            >
+              キャンセル
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+            >
+              {loading ? '作成中...' : '作成'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/validations/task.ts
+++ b/src/lib/validations/task.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod'
+
+export const createTaskSchema = z.object({
+  title: z.string().min(1, 'タイトルは必須です'),
+  description: z.string().optional(),
+  priority: z.enum(['URGENT', 'HIGH', 'MEDIUM', 'LOW', 'NONE']).default('NONE'),
+  assigneeId: z.string().optional(),
+  dueDate: z.string().optional(),
+  status: z.enum(['BACKLOG', 'TODO', 'IN_PROGRESS', 'IN_REVIEW', 'DONE']).default('BACKLOG'),
+})
+
+export type CreateTaskInput = z.infer<typeof createTaskSchema>


### PR DESCRIPTION
## 概要

カンバンボード画面でタスクの一覧表示と新規作成ができるお手本機能を実装。API + UI の基本パターンを確立する。

Closes #6

## 変更内容

### 新規ファイル

| ファイル | 内容 |
|---|---|
| `src/lib/validations/task.ts` | タスク作成の zod バリデーションスキーマ |
| `src/app/api/projects/[id]/tasks/route.ts` | GET（一覧）/ POST（作成）API、認証・バリデーション・エラーハンドリング |
| `src/components/tasks/TaskCard.tsx` | タスクカード（番号、タイトル、優先度バッジ、担当者アバター、期限） |
| `src/components/board/KanbanColumn.tsx` | カンバンカラム（タスク数表示、クイック作成ボタン） |
| `src/components/board/KanbanBoard.tsx` | カンバンボード（5カラム、モーダル制御） |
| `src/components/tasks/TaskCreateModal.tsx` | タスク作成モーダル（タイトル・説明・優先度・期限、zod バリデーション） |
| `src/app/(main)/projects/[id]/board/page.tsx` | ボードページ（Server Component、Prisma 直接クエリ） |

### API

| メソッド | パス | 概要 |
|---|---|---|
| GET | `/api/projects/[id]/tasks` | タスク一覧（assignee, reporter, categories を include） |
| POST | `/api/projects/[id]/tasks` | タスク作成（タスク番号自動採番） |

### アーキテクチャ

- **Server Component**: ボードページで Prisma 直接クエリ
- **Client Component**: KanbanBoard（状態管理）、TaskCreateModal（フォーム）
- **API Route**: 外部連携・クライアントからのタスク作成用
- **統一レスポンス**: `{ data: T }` / `{ error: { code, message } }`
- **zod バリデーション**: API / クライアント両方で使用

### カンバンボード

- 5カラム: BACKLOG / TODO / IN_PROGRESS / IN_REVIEW / DONE
- カラムごとのタスク数表示
- クイック作成ボタン（カラムのステータスで即座にモーダル表示）

## 依存追加

| パッケージ | 理由 |
|---|---|
| `date-fns` | 日付フォーマット |

## テスト結果

- `next build` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Project Kanban board for viewing and managing tasks organized by status columns (Backlog, To Do, In Progress, In Review, Done)
  * Task creation modal with title, description, priority, due date, and assignee fields
  * Task cards displaying priority badges, due dates, and assignee avatars

* **Chores**
  * Added date-fns library dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->